### PR TITLE
Add ofertas_postulaciones.sql to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+ofertas_postulaciones.sql
 # C extensions
 *.so
 


### PR DESCRIPTION
Creación de DML para ofertas y postulaciones + actualización de .gitignore

Posteriormente, se incluyó el archivo ofertas_postulaciones.sql en el .gitignore para evitar que se versionen datos sensibles o archivos generados localmente.

